### PR TITLE
prereqs: % char wasn't being scaped

### DIFF
--- a/pkg/cmd/prereqs/prereqs.go
+++ b/pkg/cmd/prereqs/prereqs.go
@@ -169,6 +169,7 @@ var filenameEscaper = strings.NewReplacer(
 	`~`, `\~`,
 	`$`, `$$`,
 	`#`, `\#`,
+        `%`, `\%`,
 )
 
 func run(w io.Writer, path string, includeTest bool, binName string) error {


### PR DESCRIPTION
% char wasn't being scaped, in consequence cockroach wasn't usable as a dependency on go modules aware project, because specialchars are not being supported by golang's archive/zip